### PR TITLE
Merge patch by nytpu: Avoid infinite loop when reading assembly file

### DIFF
--- a/libgrit/pathfun.cpp
+++ b/libgrit/pathfun.cpp
@@ -870,7 +870,7 @@ bool im_data_gas(FILE* fp, const char* name, const void *_data, int *len, int *c
             search[1] = 0;
             if(sscanf(tread, ".%s 0x", search+1))
             {
-                for(i=0; i<5; i<<=1) {
+                for(i=1; i<5; i<<=1) {
                     if(!strcmp(search, cGasTypes[i]))
                     {
                         _chunk = i;


### PR DESCRIPTION
> When reading in shared data from an assembly file, the loop (weirdly...) uses a left shift instead of a normal iteration when determining the assembly datatype.  However, it started the loop variable at 0, so it would remain at 0 after a left shift and loop infinitely.  This sets the loop variable to 1, which seems to have been the intention since the cGasTypes contains empty dummy entries to accommodate the shifting method.

LGTM, sounds like a good idea to get it into the 1.3.0 release window.