### PR TITLE
C23 Clang/LLVM compatibility

### DIFF
--- a/libplum/libplum.c
+++ b/libplum/libplum.c
@@ -596,11 +596,11 @@ struct PNM_image_header {
 
 
 // JPEG block coordinates in zig-zag order (mapping cell indexes to (x, y) coordinates)
-static const alignto(64) uint8_t JPEG_zigzag_rows[] = {
+alignto(64) static const uint8_t JPEG_zigzag_rows[] = {
   0, 0, 1, 2, 1, 0, 0, 1, 2, 3, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3,
   4, 5, 6, 7, 7, 6, 5, 4, 3, 2, 1, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 3, 4, 5, 6, 7, 7, 6, 5, 6, 7, 7
 };
-static const alignto(64) uint8_t JPEG_zigzag_columns[] = {
+alignto(64) static const uint8_t JPEG_zigzag_columns[] = {
   0, 1, 0, 0, 1, 2, 3, 2, 1, 0, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4,
   3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 3, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 5, 6, 7, 7, 6, 7
 };


### PR DESCRIPTION
Fixes a compile error; Clang requires `alignas` to come before `static const` when targeting C23/gnu23 (alignto is a #define of alignas).